### PR TITLE
Deps/missing lodash inspector

### DIFF
--- a/packages/libp2p-devtools/package.json
+++ b/packages/libp2p-devtools/package.json
@@ -152,6 +152,7 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.0.323",
+    "@types/lodash": "^4.17.20",
     "@types/react": "^19.1.5",
     "@types/react-dom": "^19.1.5",
     "@types/react-syntax-highlighter": "^15.5.13",

--- a/packages/libp2p-devtools/package.json
+++ b/packages/libp2p-devtools/package.json
@@ -153,6 +153,7 @@
   "devDependencies": {
     "@types/chrome": "^0.0.323",
     "@types/lodash": "^4.17.20",
+    "@types/multicast-dns": "^7.2.4",
     "@types/react": "^19.1.5",
     "@types/react-dom": "^19.1.5",
     "@types/react-syntax-highlighter": "^15.5.13",

--- a/packages/libp2p-devtools/package.json
+++ b/packages/libp2p-devtools/package.json
@@ -130,7 +130,7 @@
   "scripts": {
     "clean": "aegir clean",
     "lint": "aegir lint",
-    "build": "tsc && node esbuild.js",
+    "build": "tsc -b . && node esbuild.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "dep-check": "aegir dep-check",
     "start:firefox": "web-ext run --source-dir . --verbose --devtools",

--- a/packages/libp2p-devtools/src/service-worker.ts
+++ b/packages/libp2p-devtools/src/service-worker.ts
@@ -39,12 +39,12 @@ browser.runtime.onConnect.addListener(port => {
       tabId = message.tabId
     }
 
-    if (toDevTools[tabId] !== port) {
+    if (tabId != null && toDevTools[tabId] !== port) {
       toDevTools[tabId]?.onMessage.removeListener(onDevToolsPanelMessage)
       toDevTools[tabId] = port
     }
 
-    if (toContentScript[tabId] == null) {
+    if (tabId != null && toContentScript[tabId] == null) {
       toContentScript[tabId] = browser.tabs.connect(message.tabId, {
         name: SOURCE_SERVICE_WORKER
       })
@@ -59,12 +59,15 @@ browser.runtime.onConnect.addListener(port => {
     }
 
     // intercept copy-to-clipboard message
-    if (message.type === 'copy-to-clipboard') {
-      copyToClipboard(tabId, message.value); return
+    if (message.type === 'copy-to-clipboard' && tabId != null) {
+      copyToClipboard(tabId, message.value)
+      return
     }
 
     // forward message to content script
-    toContentScript[tabId].postMessage(message)
+    if (tabId != null) {
+      toContentScript[tabId].postMessage(message)
+    }
   }
 
   // Listen to messages sent from the DevTools page
@@ -106,8 +109,8 @@ browser.tabs?.onUpdated.addListener((tabId, changeInfo): void => {
   }
 })
 
-function copyToClipboard (tabId: number, text: string): void {
-  function contentCopy (text: string): void {
+function copyToClipboard(tabId: number, text: string): void {
+  function contentCopy(text: string): void {
     const input = document.createElement('textarea')
 
     // position absolutely to stop the page from jumping when we call .focus()


### PR DESCRIPTION
Addresses the issues seen in https://github.com/ipshipyard/js-libp2p-inspector/issues/23

- Added missing types dependencies for lodash and multicast-dns
- tsc wasn't compiling references, adding the -b build flag does
- typescript typing errors